### PR TITLE
Working nix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ jwk.json
 scarf
 .DS_Store
 docs/site/
-
+/*.nix
+/.envrc
+/result*


### PR DESCRIPTION
Problem:

In order to easily build JavaScript packages with Nix, we need some local files generated with node2nix present. This is because the files generated with node2nix expect to access package.json from a relative path. We also override the attributes for Nix so when we build locally we pick up the local source directory (not a release.) 

We also need default.nix and shell.nix present to reduce typing when we build or enter the Nix shell.

Solution:

Of course, add these files so everything works nicely.