### PR TITLE
Add Docker package type

### DIFF
--- a/src/Scarf/PackageSpec.hs
+++ b/src/Scarf/PackageSpec.hs
@@ -82,13 +82,15 @@ platformForPackageType t = case t of
 -- Scarf package manager. The distinction between library types and package
 -- types is hazy, and should probably be renamed going forward.
 data ExternalLibraryType
-  = LibNPM
+  = Docker
+  | LibNPM
   | Hackage
   | PyPI
   | Other
   deriving (Show, Read, Eq, Enum, Generic)
 
 fromLibraryTypeName :: Monad m => Text -> m ExternalLibraryType
+fromLibraryTypeName "docker" = return Docker
 fromLibraryTypeName "npm" = return LibNPM
 fromLibraryTypeName "hackage" = return Hackage
 fromLibraryTypeName "pypi" = return PyPI
@@ -96,6 +98,7 @@ fromLibraryTypeName "other" = return Other
 fromLibraryTypeName other = fail . toString $ "Could not parse library type from string: " <> other
 
 toLibraryTypeName :: ExternalLibraryType -> Text
+toLibraryTypeName Docker = "docker"
 toLibraryTypeName LibNPM  = "npm"
 toLibraryTypeName Hackage = "hackage"
 toLibraryTypeName PyPI    = "pypi"

--- a/src/Scarf/Types.hs
+++ b/src/Scarf/Types.hs
@@ -107,6 +107,8 @@ data CreatePackageRequest =
     , createPackageRequestLongDescription :: Maybe Text
     , createPackageRequestWebsite :: Maybe Text
     , createPackageRequestExternalLibraryType :: Maybe Scarf.PackageSpec.ExternalLibraryType
+    , createPackageRequestGatewayPublicUrl :: Maybe Text
+    , createPackageRequestGatewayBackendUrl :: Maybe Text
     }
 deriveJSON
   defaultOptions


### PR DESCRIPTION
As part of the work for this issue about Model changes for Registry Gateway in Scarf Server: https://github.com/scarf-sh/scarf-server/issues/117

- Add `Docker` package type to `PackageSpec`
- Update `CreatePackageRequest` type to include the gateway's public & backend urls