### PR TITLE
README install and usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,7 +35,8 @@ You can test that Scarf works by creating and installing a package in a Scarf en
 3. Remove Nix's Node.js package from your environment. Run ~scarf env remove nixpkgs:node~.
 
 ** Usage
-All ~scarf env~ subcommands accept an ~--environment~ flag, to operate on/within a specified environment. The default is the user's global environment.
+
+~scarf~ has one subcommand, ~env~. All ~scarf env~ subcommands accept an ~--environment~ flag, to operate on/within a specified environment. The default is the user's global environment.
 
 - ~scarf env enter CMD [ARGS ...]~ :: Run ~CMD ARGS...~ inside the environment
 - ~scarf env add PKG~ :: Add ~PKG~ to the environment, if it's not already there

--- a/README.org
+++ b/README.org
@@ -8,13 +8,40 @@ The Scarf CLI is a set of tools aimed at empowering users and maintainers of ope
 Each of the Scarf commands uses the general abstractions provided by Nomia to identify their resources. For example, when adding a package to an environment with the Environment Manager, you would specify the package to add and the environment to add it to by name, using the common Nomia conventions for string representations of names. This provides a unified interface to specified disparate areas of software distribution and development. Now they can be seamlessly combined and efficiently realized, while also enabling integration with any other system that offers Nomia resources.
 * Environment Manager
 The Scarf Environment Manager is used to manage the environments for user sessions, development workflows, and automated systems. It is similar to a package manager, except in that it treats environments as first-class resources to be manipulated, combined, transferred, etc.
+
+* Get started
+
+** Before you begin
+
+To install and use the Scarf CLI, you must have [[https://nixos.org/download.html][Nix]] and [[https://git-scm.com/downloads][Git]] installed.
+
+** Install
+
+1. Clone this repository and switch to it. Run ~git clone https://github.com/scarf-sh/scarf.git && cd scarf~.
+2. Run ~./install~.
+
+** Try it
+
+You can test that Scarf works by creating and installing a package in a Scarf environment. Try this:
+
+1. Install Nix's Node.js package into your default user environment. Run ~scarf env add nixpkgs:node~.
+2. Compare your system with the Scarf environment. Run these commands:
+   
+   #+BEGIN_SRC sh
+     $ which node  // shows path to system Node.js, if any
+     $ scarf env enter which node  // shows path to Nix-provided Node.js
+   #+END_SRC
+
+3. Remove Nix's Node.js package from your environment. Run ~scarf env remove nixpkgs:node~.
+
 ** Usage
 All ~scarf env~ subcommands accept an ~--environment~ flag, to operate on/within a specified environment. The default is the user's global environment.
 
 - ~scarf env enter CMD [ARGS ...]~ :: Run ~CMD ARGS...~ inside the environment
 - ~scarf env add PKG~ :: Add ~PKG~ to the environment, if it's not already there
 - ~scarf env remove PKG~ :: Remove ~PKG~ from the environment
-** Packages
+
+* Packages
 Packages are units of software ready to use as files or directories in the filesystem, together with any other system resources needed for the software to function. Currently packages are implemented on top of [[https://nixos.org][Nix]], though eventually they will be implemented on top of native Nomia package namespaces.
 *** ~scarf-pkgset~ package namespace
 The ~scarf-pkgset~ namespace is the default namespace for adding and removing packages. Names within the namespace are simply package names, e.g. ~scarf-pkgset:vim~ is the [[https://www.vim.org/][Vim]] editor.
@@ -24,7 +51,8 @@ Eventually this will be a curated package set, offering access to software from 
 The ~nixpkgs~ namespace is a namespace of packages, pulled from the [[https://nixos.org/manual/nixpkgs/stable/][nixpkgs]] package set. The namespace takes an optional ~revision~ parameter specifying a git revision to pull; when omitted, ~nixpkgs~ is found in your ~NIX_PATH~. Names within the namespace correspond to top-level package attributes in ~nixpkgs~.
 
 As use cases evolve, we may expose names for more complex Nix-derived constructions and manipluations, possibly up to arbitrary Nix expressions.
-** Environments
+
+* Environments
 An environment is the background context within which some process or other computational unit runs.
 
 Currently, environments include a set of packages, which are made available to processes running inside of them.
@@ -46,9 +74,5 @@ The Scarf Service Manager will enable management of services in a way that integ
 Our goal is that the default package resolution underlying the Scarf tools will source package definitions, tarballs, and binaries through Scarf's [[https://about.scarf.sh/scarf-gateway][Gateway]] registry. When fully implemented, this will enable us to empower maintainers with aggregate anonymized download statistics without compromising end-user privacy or sending any unexpected information from the end user's machine.
 
 End-users will always retain the ability to configure their own namespaces and upstream registries. Scarf does not store personally identifiable information.
-* Installing
-The Scarf CLI currently relies on [[https://nixos.org][Nix]]. If you don't yet have it installed, please follow the [[https://nixos.org/download.html][upstream instructions]].
-
-Then, simply run the ~install~ script in this directory.
 
 [[https://static.scarf.sh/a.png?x-pxid=b79d2b7f-75f9-424c-96f7-35895f459006]]


### PR DESCRIPTION
This reworks the installation and usage instructions as outlined in https://github.com/scarf-sh/scarf/issues/22#issue-872989789. I had one goal here: straighten the path from "I want to use this, now what?" to "I got scarf to do one useful thing." The README now has a subsection that consists of:

1. Prerequisites
2. Installation instructions
3. A 'hello world' demonstration
4. Usage instructions

I'll highlight a couple of other interesting things in a self-review.